### PR TITLE
[Add]カレンダープログラムの作成

### DIFF
--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -2,35 +2,24 @@
 require 'date'
 require 'optparse'
 
-# コマンドラインオプション設定(デフォルト値は今日の年と月)
 params = ARGV.getopts("m:", "y:", "m:#{Date.today.mon}", "y:#{Date.today.year}")
 month = params["m"].to_i
 year = params["y"].to_i
 
-# 月の最初の日にちを取得
 start_date = Date.new(year, month, 1)
-
-# 月の最終日を取得
 end_date = Date.new(year, month, -1)
 
-# 月と年を取得
 header = "#{start_date.mon}月 #{start_date.year}"
 puts header.center(20)
-# すべての曜日を取得
+
 puts "日 月 火 水 木 金 土"
 
-margin_space = Array.new(start_date.wday, "  ")
-
-
-# 配列の要素を文字列型に変更、各要素を右寄せ
-# 1日ではないかつ、日曜日の日付の場合日付の前に改行文字を入れて改行
 calendar_formatted = (start_date..end_date).map do |date|
   day_to_string = date.day.to_s.rjust(2)
   date.day != 1 && date.sunday? ? "\n" + day_to_string : day_to_string
 end
 
-# 余白と日付の配列を連結
-calendar = margin_space + calendar_formatted
+margin_space = Array.new(start_date.wday, "  ")
 
-# カレンダーを表示
+calendar = margin_space + calendar_formatted
 puts calendar.join(" ")

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -3,7 +3,7 @@ require 'date'
 require 'optparse'
 
 # コマンドラインオプション設定(デフォルト値は今日の年と月)
-params =ARGV.getopts("m:", "y:", "m:#{Date.today.mon}", "y:#{Date.today.year}")
+params = ARGV.getopts("m:", "y:", "m:#{Date.today.mon}", "y:#{Date.today.year}")
 input_month = params["m"].to_i
 input_year = params["y"].to_i
 

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -19,7 +19,7 @@ formatted_calendar = (start_date..end_date).map do |date|
   date.day != 1 && date.sunday? ? "\n" + day : day
 end
 
-margin_space = Array.new(start_date.wday, "  ")
+margin = Array.new(start_date.wday, "  ")
 
-calendar = margin_space + formatted_calendar
+calendar = margin + formatted_calendar
 puts calendar.join(" ")

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -16,8 +16,9 @@ puts "日 月 火 水 木 金 土"
 
 formatted_days = (start_date..end_date).map do |date|
   day = date.day.to_s.rjust(2)
-  date.saturday? ? day + "\n" : day + " "
+  day + (date.saturday? ? "\n" : " ")
 end
+
 margin = Array.new(start_date.wday, "   ")
 
 calendar = margin + formatted_days

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -28,7 +28,8 @@ all_days = (start_date.day..end_date.day).to_a
 # 1日ではないかつ、日曜日の日付の場合日付の前に改行文字を入れて改行
 calendar_formatted = all_days.map do |day|
                        date = Date.new(start_date.year, start_date.mon, day)
-                       day != 1 && date.sunday? ? "\n" + day.to_s.rjust(2) : day.to_s.rjust(2)
+                       day_to_string = day.to_s.rjust(2)
+                       date.day != 1 && date.sunday? ? "\n" + day_to_string : day_to_string
                      end
 
 # 余白と日付の配列を連結

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -9,7 +9,7 @@ year = params["y"].to_i
 start_date = Date.new(year, month, 1)
 end_date = Date.new(year, month, -1)
 
-header = "#{start_date.mon}月 #{start_date.year}"
+header = "#{month}月 #{year}"
 puts header.center(20)
 
 puts "日 月 火 水 木 金 土"

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -4,11 +4,11 @@ require 'optparse'
 
 # コマンドラインオプション設定(デフォルト値は今日の年と月)
 params = ARGV.getopts("m:", "y:", "m:#{Date.today.mon}", "y:#{Date.today.year}")
-input_month = params["m"].to_i
-input_year = params["y"].to_i
+month = params["m"].to_i
+year = params["y"].to_i
 
 # 月の最初の日にちを取得
-start_date = Date.new(input_year, input_month, 1)
+start_date = Date.new(year, month, 1)
 
 # 月の最終日を取得
 end_date = Date.new(start_date.year, start_date.mon, -1)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -15,8 +15,8 @@ puts header.center(20)
 puts "日 月 火 水 木 金 土"
 
 formatted_calendar = (start_date..end_date).map do |date|
-  day_to_string = date.day.to_s.rjust(2)
-  date.day != 1 && date.sunday? ? "\n" + day_to_string : day_to_string
+  day = date.day.to_s.rjust(2)
+  date.day != 1 && date.sunday? ? "\n" + day : day
 end
 
 margin_space = Array.new(start_date.wday, "  ")

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -34,4 +34,3 @@ calendar = margin_space + calendar_formatted
 
 # カレンダーを表示
 puts calendar.join(" ")
-

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -15,7 +15,7 @@ end_date = Date.new(year, month, -1)
 
 # 月と年を取得
 header = "#{start_date.mon}月 #{start_date.year}"
-
+puts header.center(20)
 # すべての曜日を取得
 week_days = ["日", "月", "火", "水", "木", "金", "土"]
 
@@ -39,5 +39,5 @@ calendar_formatted = all_days.map do |day|
 calendar = margin_space + calendar_formatted
 
 # カレンダーを表示
-puts header.center(20), week_days.join(" "), calendar.join(" ")
+puts week_days.join(" "), calendar.join(" ")
 

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+require 'date'
+require 'optparse'
+
+# コマンドラインオプション設定(デフォルト値は今日の年と月)
+params =ARGV.getopts("m:", "y:", "m:#{Date.today.mon}", "y:#{Date.today.year}")
+input_month = params["m"].to_i
+input_year = params["y"].to_i
+
+# 月の最初の日にちを取得
+start_date = Date.new(input_year, input_month, 1)
+# 月の最終日を取得
+end_date = Date.new(start_date.year, start_date.mon, -1)
+
+# 月と年を取得
+header = "#{start_date.mon}月 #{start_date.year}"
+
+# すべての曜日を取得
+week_days = ["日", "月", "火", "水", "木", "金", "土"]
+
+# カレンダーの最初の日までの余白を配列で作成
+margin_space = []
+start_date.wday.times do
+  margin_space.unshift("  ")
+end
+
+# すべての日付を配列で作成
+all_days = (start_date.day..end_date.day).to_a
+
+# 配列の要素を文字列型に変更、1日ではない&&土曜日で改行, 各要素を右寄せ
+calendar_formatted = all_days.map do |day|
+  date = Date.new(start_date.year, start_date.mon, day)
+  day != 1 && date.sunday? ? "\n" + day.to_s.rjust(2) : day.to_s.rjust(2)
+end
+# 余白と日付の配列を連結
+calendar = margin_space + calendar_formatted
+
+# カレンダーを表示
+puts header.center(20)
+puts week_days.join(" ")
+puts calendar.join(" ")
+

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -16,10 +16,9 @@ puts "日 月 火 水 木 金 土"
 
 formatted_days = (start_date..end_date).map do |date|
   day = date.day.to_s.rjust(2)
-  date.day != 1 && date.sunday? ? "\n" + day : day
+  date.saturday? ? day + "\n" : day + " "
 end
-
-margin = Array.new(start_date.wday, "  ")
+margin = Array.new(start_date.wday, "   ")
 
 calendar = margin + formatted_days
-puts calendar.join(" ")
+puts calendar.join

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -17,7 +17,7 @@ end_date = Date.new(year, month, -1)
 header = "#{start_date.mon}月 #{start_date.year}"
 puts header.center(20)
 # すべての曜日を取得
-week_days = ["日", "月", "火", "水", "木", "金", "土"]
+puts "日 月 火 水 木 金 土"
 
 # カレンダーの最初の日までの余白を配列で作成
 margin_space = []
@@ -39,5 +39,5 @@ calendar_formatted = all_days.map do |day|
 calendar = margin_space + calendar_formatted
 
 # カレンダーを表示
-puts week_days.join(" "), calendar.join(" ")
+puts calendar.join(" ")
 

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -11,7 +11,7 @@ year = params["y"].to_i
 start_date = Date.new(year, month, 1)
 
 # 月の最終日を取得
-end_date = Date.new(start_date.year, start_date.mon, -1)
+end_date = Date.new(year, month, -1)
 
 # 月と年を取得
 header = "#{start_date.mon}月 #{start_date.year}"

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -14,12 +14,12 @@ puts header.center(20)
 
 puts "日 月 火 水 木 金 土"
 
-calendar_formatted = (start_date..end_date).map do |date|
+formatted_calendar = (start_date..end_date).map do |date|
   day_to_string = date.day.to_s.rjust(2)
   date.day != 1 && date.sunday? ? "\n" + day_to_string : day_to_string
 end
 
 margin_space = Array.new(start_date.wday, "  ")
 
-calendar = margin_space + calendar_formatted
+calendar = margin_space + formatted_calendar
 puts calendar.join(" ")

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -14,12 +14,12 @@ puts header.center(20)
 
 puts "日 月 火 水 木 金 土"
 
-formatted_calendar = (start_date..end_date).map do |date|
+formatted_days = (start_date..end_date).map do |date|
   day = date.day.to_s.rjust(2)
   date.day != 1 && date.sunday? ? "\n" + day : day
 end
 
 margin = Array.new(start_date.wday, "  ")
 
-calendar = margin + formatted_calendar
+calendar = margin + formatted_days
 puts calendar.join(" ")

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -19,11 +19,7 @@ puts header.center(20)
 # すべての曜日を取得
 puts "日 月 火 水 木 金 土"
 
-# カレンダーの最初の日までの余白を配列で作成
-margin_space = []
-start_date.wday.times do
-  margin_space.unshift("  ")
-end
+margin_space = Array.new(start_date.wday, "  ")
 
 # すべての日付を配列で作成
 all_days = (start_date.day..end_date.day).to_a

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -9,6 +9,7 @@ input_year = params["y"].to_i
 
 # 月の最初の日にちを取得
 start_date = Date.new(input_year, input_month, 1)
+
 # 月の最終日を取得
 end_date = Date.new(start_date.year, start_date.mon, -1)
 
@@ -27,16 +28,16 @@ end
 # すべての日付を配列で作成
 all_days = (start_date.day..end_date.day).to_a
 
-# 配列の要素を文字列型に変更、1日ではない&&土曜日で改行, 各要素を右寄せ
+# 配列の要素を文字列型に変更、各要素を右寄せ
+# 1日ではないかつ、日曜日の日付の場合日付の前に改行文字を入れて改行
 calendar_formatted = all_days.map do |day|
-  date = Date.new(start_date.year, start_date.mon, day)
-  day != 1 && date.sunday? ? "\n" + day.to_s.rjust(2) : day.to_s.rjust(2)
-end
+                       date = Date.new(start_date.year, start_date.mon, day)
+                       day != 1 && date.sunday? ? "\n" + day.to_s.rjust(2) : day.to_s.rjust(2)
+                     end
+
 # 余白と日付の配列を連結
 calendar = margin_space + calendar_formatted
 
 # カレンダーを表示
-puts header.center(20)
-puts week_days.join(" ")
-puts calendar.join(" ")
+puts header.center(20), week_days.join(" "), calendar.join(" ")
 

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -21,16 +21,13 @@ puts "日 月 火 水 木 金 土"
 
 margin_space = Array.new(start_date.wday, "  ")
 
-# すべての日付を配列で作成
-all_days = (start_date.day..end_date.day).to_a
 
 # 配列の要素を文字列型に変更、各要素を右寄せ
 # 1日ではないかつ、日曜日の日付の場合日付の前に改行文字を入れて改行
-calendar_formatted = all_days.map do |day|
-                       date = Date.new(start_date.year, start_date.mon, day)
-                       day_to_string = day.to_s.rjust(2)
-                       date.day != 1 && date.sunday? ? "\n" + day_to_string : day_to_string
-                     end
+calendar_formatted = (start_date..end_date).map do |date|
+  day_to_string = date.day.to_s.rjust(2)
+  date.day != 1 && date.sunday? ? "\n" + day_to_string : day_to_string
+end
 
 # 余白と日付の配列を連結
 calendar = margin_space + calendar_formatted


### PR DESCRIPTION
# 概要
- カレンダープログラムを作成しました

# チェック項目
- [x] ./cal.rb で実行できること(ruby cal.rb としなくてよいこと)
- [x] -mで月を、-yで年を指定できる
- [x] MacやWSLに入っているcalコマンドと同じ見た目になっている
- [x] 少なくとも1970年から2100年までは正しく表示される(多分)

# コマンド実行比較
## オプションなし
<img width="675" alt="cal_today" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/93c70a83-3771-4f20-9271-a95f878c525d">

## オプションあり
### 年(-y)のみ
<img width="675" alt="cal_year" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/d0e39e72-7eba-4393-90aa-72f004a13494">

### 月(-m)のみ
<img width="675" alt="cal_mon" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/4212903e-59d5-4648-9e8a-3364a29f510a">

## 2100年 5月
<img width="675" alt="cal_2100_5" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/953e0269-3a86-4ea9-a368-478583f38a7a">

## 1970年 7月
<img width="675" alt="cal_1970_7" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/8a70eec3-491b-4d2f-967f-e59be057b27b">
