### PR TITLE
lsコマンドを作る2 -aオプションの追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,8 +1,15 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 def main
-  filenames = Dir.glob('*')
+  options = ARGV.getopts('a')
+  filenames = if options['a']
+                Dir.glob('*', File::FNM_DOTMATCH)
+              else
+                Dir.glob('*')
+              end
   arranged_filenames = arrange_filenames(filenames)
   filenames_matrix = create_filenames_matrix(arranged_filenames)
   output(filenames_matrix)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -5,11 +5,8 @@ require 'optparse'
 
 def main
   options = ARGV.getopts('a')
-  filenames = if options['a']
-                Dir.glob('*', File::FNM_DOTMATCH)
-              else
-                Dir.glob('*')
-              end
+  flags = options['a'] ? File::FNM_DOTMATCH : 0
+  filenames = Dir.glob('*', flags)
   arranged_filenames = arrange_filenames(filenames)
   filenames_matrix = create_filenames_matrix(arranged_filenames)
   output(filenames_matrix)


### PR DESCRIPTION
## 概要
- lsコマンドに-aオプションを追加しました。

## RuboCop結果 → 問題なし
```
# jun.k @ mcbk in ~/workspace/fjord/ruby-practices/04.ls on git:my-ls-a x [22:28:06] 
$ rubocop ls.rb
Inspecting 1 file
.

1 file inspected, no offenses detected

```

## コマンド実行結果 → 問題なし
### mac標準の`ls -a`コマンド
<img width="849" alt="image" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/2047758a-660a-4b1b-a052-f6ee079f98fe">

### 自作の`ls -a`コマンド
ちょっと見辛いですが、並び順問題ありませんでした。親ディレクトリ("‥")の表示は未実装です。
<img width="818" alt="image" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/842baa52-f86f-4906-bcd6-863596683d63">


