### PR TITLE
lsコマンドを作る4 -lオプションの追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -10,12 +10,10 @@ def list_filenames(flags, options)
 end
 
 def main
-  options = ARGV.getopts('ar')
+  options = ARGV.getopts('arl')
   flags = options['a'] ? File::FNM_DOTMATCH : 0
   filenames = list_filenames(flags, options)
-  arranged_filenames = arrange_filenames(filenames)
-  filenames_matrix = create_filenames_matrix(arranged_filenames)
-  output(filenames_matrix)
+  options['l'] ? long_listing(filenames) : short_listing(filenames)
 end
 
 def display_file_width(str)
@@ -38,11 +36,10 @@ def create_filenames_matrix(arranged_names, col: 3)
   arranged_names.each_slice(row).map { |divided_names| divided_names + Array.new((row - divided_names.size), '') }.transpose
 end
 
-def output(filenames_matrix)
-  filenames_matrix.each do |filenames|
-    filenames.each { |filename| print filename }
-    puts
-  end
+def short_listing(filenames)
+  arranged_filenames = arrange_filenames(filenames)
+  filenames_matrix = create_filenames_matrix(arranged_filenames)
+  filenames_matrix.map(&:join).join("\n")
 end
 
-main
+puts main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -125,17 +125,6 @@ def other_users_permission(sticky, permission_number)
   end
 end
 
-def check_max_stat_sizes(stats)
-  max_size_owner = stats.max_by { |s| Etc.getpwuid(s.uid).name.size }
-  max_size_group = stats.max_by { |s| Etc.getgrgid(s.gid).name.size }
-  {
-    max_nlink_size: stats.max_by { |s| s.nlink.to_s.size }.nlink.to_s.size,
-    max_file_size: stats.max_by(&:size).size.to_s.size,
-    max_size_owner_size: Etc.getpwuid(max_size_owner.uid).name.size,
-    max_size_group_size: Etc.getgrgid(max_size_group.gid).name.size
-  }
-end
-
 def check_max_length(element)
   element.max_by(&:length).length
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -131,14 +131,14 @@ def generate_body(file_stats, max_sizes)
       Etc.getpwuid(file[:stat].uid).name.ljust(max_sizes[:max_size_owner_size] + 1),
       Etc.getgrgid(file[:stat].gid).name.ljust(max_sizes[:max_size_group_size] + 1),
       file[:stat].size.to_s.rjust(max_sizes[:max_file_size]),
-      show_date_modified(file[:stat]),
+      format_mtime(file[:stat]),
       file[:name],
       show_symlink(file[:name])
     ].join(' ').rstrip
   end
 end
 
-def show_date_modified(stat)
+def format_mtime(stat)
   date_modified = stat.mtime
   Date.parse(date_modified.to_s) < Date.today << 6 ? date_modified.strftime('%_m %_d %_5Y') : date_modified.strftime('%_m %_d %H:%M')
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -68,7 +68,7 @@ def check_file_type(type)
   }[type]
 end
 
-def output_normal_permission(permission_number)
+PERMISSION =
   {
     '7' => 'rwx',
     '6' => 'rw-',
@@ -78,40 +78,31 @@ def output_normal_permission(permission_number)
     '2' => '-w-',
     '1' => '--x',
     '0' => '---'
-  }[permission_number]
+  }.freeze
+
+def output_normal_permission(permission_number)
+  PERMISSION[permission_number]
 end
 
 def owner_and_group_permission(set_id, permission_number)
-  if set_id
-    {
-      '7' => 'rws',
-      '6' => 'rwS',
-      '5' => 'r-s',
-      '4' => 'r-S',
-      '3' => '-ws',
-      '2' => '-wS',
-      '1' => '--s',
-      '0' => '---'
-    }[permission_number]
+  permission = output_normal_permission(permission_number)
+  if set_id && permission[2] == 'x'
+    permission.sub(/x/, 's')
+  elsif set_id
+    permission.sub(/-/, 'S')
   else
-    output_normal_permission(permission_number)
+    permission
   end
 end
 
 def other_users_permission(sticky, permission_number)
-  if sticky
-    {
-      '7' => 'rwt',
-      '6' => 'rwT',
-      '5' => 'r-t',
-      '4' => 'r-T',
-      '3' => '-wt',
-      '2' => '-wT',
-      '1' => '--t',
-      '0' => '---'
-    }[permission_number]
+  permission = output_normal_permission(permission_number)
+  if sticky && permission[2] == 'x'
+    permission.sub(/x/, 't')
+  elsif sticky
+    permission.sub(/-/, 'T')
   else
-    output_normal_permission(permission_number)
+    permission
   end
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -48,7 +48,7 @@ def long_listing(filenames)
   file_stats = filenames.map do |filename|
     { name: filename, stat: File.lstat(filename) }
   end
-  elements = collect_elements(file_stats)
+  elements = file_stats_for_long_format(file_stats)
   long_list = generate_body(elements)
   total_block_number = elements.map { _1[:block] }.inject { |total, block| total + block }
   total_block = "total #{total_block_number}"

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -55,7 +55,7 @@ def long_listing(filenames)
   [total_block, long_list].join("\n")
 end
 
-def collect_elements(file_stats)
+def file_stats_for_long_format(file_stats)
   file_stats.map do |file|
     file_mode_number = file[:stat].mode.to_s(8).slice(-3, 3)
     {


### PR DESCRIPTION
## 概要
- lsコマンドに-lオプションを追加しました。
- コマンドラインのオプションにlオプションがある場合、`long_listing`メソッドが実行され詳細情報のリストが表示されます。ない場合はファイル名のみのリストが表示されます。
## RuboCop結果 → 問題なし
<img width="710" alt="image" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/9114547c-fef0-41dd-8f11-f8e57525619e">

## コマンド実行結果比較
以下os標準のコマンドとの比較結果になります。
目視ですが非対応の箇所以外は表示内容が揃っていることは確認出来ました。
## 比較1
- ファイルのパーミッションの右端に表示される`@`や`+`の拡張属性の表示は非対応です。
- SUID、GUID、スティッキービット等の特殊権限の表示に対応しました。
### mac標準のls -lコマンド
<img width="710" alt="image" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/2f058f47-cad1-4446-b21e-fb473a4cfaab">

### 自作のls -lコマンド
<img width="710" alt="image" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/ac9d9aaf-1543-4f4c-a831-9db5335f8886">



## 比較2
- 変更日時が6ヶ月以上前のファイルには時間ではなく年数が表示されます。
- 所有者(owner)、所有グループ(group)が違う場合もレイアウトが崩れないようにしました。
- 日本語などの全角文字には非対応ownerやグループ名が日本語の場合レイアウトは崩れます。
### mac標準のls -lコマンド
<img width="563" alt="image" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/c0973a6b-3c54-4c39-b9bf-bfaf942d8e16">

### 自作のls -lコマンド
<img width="563" alt="image" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/307f3132-dbab-48bb-a561-16d8ba3a5f52">

## 比較3
- ファイルがシンボリック・リンクの場合参照先を表示します。
### mac標準のls -lコマンド
<img width="563" alt="image" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/18acb875-155a-48ce-a987-cca57aa95f9a">

### 自作のls -lコマンド
<img width="680" alt="image" src="https://github.com/jun-kondo/ruby-practices/assets/99650078/727a81d0-6004-4852-ba2b-c858d54ececa">

