### PR TITLE
ls コマンドを作る5

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -34,7 +34,8 @@ def arrange_filenames(names)
 end
 
 def create_filenames_matrix(arranged_names, col: 3)
-  row = arranged_names.size <= col ? 1 : arranged_names.size / col + 1
+  file_quantity = arranged_names.size
+  row = (file_quantity % col).zero? ? file_quantity / col : file_quantity / col + 1
   arranged_names.each_slice(row).map { |divided_names| divided_names + Array.new((row - divided_names.size), '') }.transpose
 end
 


### PR DESCRIPTION
## 概要
お疲れ様です。「ls コマンドを作る5」の課題を提出致します。
これまでの過程で今回の終了条件を満たした状態になっており、オプション部分の記述に追加・変更点はありません。
下記の点のみ修正を行いました。

## 修正点
コマンド対象のディレクトリ内のファイル数が6つの場合2列で表示される処理になっていたので3列になるように修正しました。
### 修正前
2列になっている
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMlZpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--e470a819c119ce4c42e1daeb282a8af76deae30a/image.png)

### 修正後
3列表示に変更
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMnBpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--caae8fde9c689711acd04a279c7624034d5786d3/image.png)

### 原因

```ruby
def create_filenames_matrix(arranged_names, col: 3)
  row = arranged_names.size <= col ? 1 : arranged_names.size / col + 1
  arranged_names.each_slice(row).map { |divided_names| divided_names + Array.new((row - divided_names.size), '') }.transpose
end
```
`create_filenames_matrix`メソッドで最終的に出力する表示の行列数を求めるのですが、ファイルが6個のときに3列目がすべて空白文字になってしまうのが原因でした。
下記のように変更しました。

```ruby
def create_filenames_matrix(arranged_names, col: 3)
  file_quantity = arranged_names.size
  row = (file_quantity % col).zero? ? file_quantity / col : file_quantity / col + 1
  arranged_names.each_slice(row).map { |divided_names| divided_names + Array.new((row - divided_names.size), '') }.transpose
end
```

## RuboCop結果
問題ありません。
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMk5pQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--638ec34911ca45a46f9cf68087864147961772bf/image.png)

## 各種コマンド実行結果
### -aオプション
`..`には非対応です。
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMlJpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--727847072cd28661d0afe68b36b0aa814b4a31da/image.png)

<macOS標準コマンド>


![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMmhpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--3b5fa7c2b12a07c60b6f13056f30f03351717dc8/image.png)


---

### -rオプション


![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMnRpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--7b211434d6758d08823473e1c7d6ac2812aa48c4/image.png)



<macOS標準コマンド>

![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMmxpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--80166e279893a094fdc5e01527e68f34bc049fbb/image.png)



---
### -lオプション

![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMlppQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--d0cc87a2e6d4e55e72c6ad97848080ad972c97c8/image.png)

<macOS標準コマンド>

![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMmRpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--46e735e03c15f4fcfe4a5148964c1aa25f685801/image.png)

---

## コマンド組み合わせ時の実行結果
### 組み合わせ: `-al`
ドットファイルが表示されたlong listになっている
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMnhpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--df251397937ec6c78204a79308a309e209a44c1f/image.png)



<macOS標準コマンド>


![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMjVpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--1bf8bb8abb92d458dd1dcba9d0880ee420534b06/image.png)


### 組み合わせ: `-alr`
ドットファイルが表示されている・ロングリスト表示となっている・逆順表示されている

![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMjFpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fc110e81cbee2b287b5361f975be47a47ef67830/image.png)


<macOS標準コマンド>


![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMjlpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--de314282310fc745e38ea4eda55ca52dcdbb6c04/image.png)

## オプション指定が順不同でも可能か
### `-rla`
逆順・ロングリスト表示・ドットファイル表示
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBM0JpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--5a7cd92781c31010a9722d98a7707e81c648dc87/image.png)

### `-lar`
ロングリスト表示・ドットファイル表示・逆順
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBM0ZpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--1d1ddf751cc83cc971dfd41600c7085df0fa1a61/image.png)

### `-la`
ロングリスト表示・ドットファイル表示
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBM0ppQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--05450bd9995b8fc78e4d6b7effc999549665b070/image.png)


### `-ra`
逆順・ドットファイル表示
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBM05pQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--612ddf70676029231dd91cdf8be55fca5e7a6cc2/image.png)

### `lr`
ロングリスト表示・逆順
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBM1JpQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--6294f5b8db4f12de6819a91243a3bfcd55957c48/image.png)

